### PR TITLE
OpenCoreUefi: Perform output setup after driver connection

### DIFF
--- a/Platform/OpenCore/OpenCoreUefi.c
+++ b/Platform/OpenCore/OpenCoreUefi.c
@@ -673,7 +673,6 @@ OcLoadUefiSupport (
     OcUnblockUnmountedPartitions ();
   }
 
-  OcLoadUefiOutputSupport (Config);
   OcMiscUefiQuirksLoaded (Config);
 
   if (Config->Uefi.ConnectDrivers) {
@@ -690,4 +689,6 @@ OcLoadUefiSupport (
   } else {
     OcLoadDrivers (Storage, Config, NULL);
   }
+
+  OcLoadUefiOutputSupport (Config);
 }


### PR DESCRIPTION
This avoids issues with macs performing drawing during connection